### PR TITLE
January fix

### DIFF
--- a/calendar.cpp
+++ b/calendar.cpp
@@ -4,12 +4,19 @@ std::string getHoliday(int month, int day)
 {
     for (int i=0;i<59;i++)
     {
-        if (month==std::stoi(PAGAN_HOLIDAYS[i][0]))
+        try
         {
-            if (day==std::stoi(PAGAN_HOLIDAYS[i][1]))
+            if (month==std::stoi(PAGAN_HOLIDAYS[i][0]))
             {
-                return PAGAN_HOLIDAYS[i][2];
+                if (day==std::stoi(PAGAN_HOLIDAYS[i][1]))
+                {
+                    return PAGAN_HOLIDAYS[i][2];
+                }
             }
+        } catch (...)
+        {
+            std::cerr << "Failed to convert " << PAGAN_HOLIDAYS[i][0] << " and " << PAGAN_HOLIDAYS[i][1] << " into ints\n";
+            continue;
         }
     }
     return "";

--- a/calendar.cpp
+++ b/calendar.cpp
@@ -1,8 +1,10 @@
 #include "calendar.h"
 
+#define ARRAY_LEN(x) (sizeof(x) / sizeof(x[0]))
+
 std::string getHoliday(int month, int day)
 {
-    for (int i=0;i<59;i++)
+    for (size_t i=0;i<ARRAY_LEN(PAGAN_HOLIDAYS);i++)
     {
         try
         {


### PR DESCRIPTION
The current master version and the latests release (0.7.0) crashes because the PAGAN_HOLIDAYS contains the line:
```
{{"01", "TueLast", "Upelly - old fire festival"}}
``` 
I have not touched that line. Instead I have improved the error handling in calendar.cpp.
First commit: It will skip lines that std::stoi does not support. It basically works as if atoi had been used just with smaller risk of UB.
The seconds commit removed the hard coded value 59. It is an UB waiting to happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/deerportal/deerportal/53)
<!-- Reviewable:end -->
