### PR TITLE
Unhardcode GNU/Linux launcher icon file path

### DIFF
--- a/deerportal.desktop
+++ b/deerportal.desktop
@@ -2,7 +2,7 @@
 Name=DeerPortal
 Comment=Board Game Driven By Classical Elements
 Exec=/opt/deerportal/DeerPortal.sh
-Icon=/usr/share/icons/hicolor/512x512/apps/deerportal.png
+Icon=deerportal
 Path=/opt/deerportal
 Terminal=false
 Type=Application


### PR DESCRIPTION
Since the icon is installed to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the icon file extension in the `.desktop` launcher. It will be found anyway.

This facilitates icon theming and makes the system automatically pickup the appropriate icon size if different sizes are provided in ``.../icons/hicolor/<size>/apps``.
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/deerportal/deerportal/57)
<!-- Reviewable:end -->
